### PR TITLE
jessica replace email with name in navbar

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -54,7 +54,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               {
                 currentUser && currentUser.loggedIn ? (
                   <>
-                    <Navbar.Text className="me-3" as={Link} to="/profile">Welcome, {currentUser.root.user.email}</Navbar.Text>
+                    <Navbar.Text className="me-3" as={Link} to="/profile">Welcome, {currentUser.root.user.givenName} {currentUser.root.user.familyName}</Navbar.Text>
                     <Button onClick={doLogout}>Log Out</Button>
                   </>
                 ) : (

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -23,7 +23,7 @@ describe("AppNavbar tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => expect(getByText("Welcome, pconrad.cis@gmail.com")).toBeInTheDocument());
+        await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
     });
 
     test("renders correctly for admin user", async () => {
@@ -39,7 +39,7 @@ describe("AppNavbar tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => expect(getByText("Welcome, phtcon@ucsb.edu")).toBeInTheDocument());
+        await waitFor(() => expect(getByText("Welcome, Phill Conrad")).toBeInTheDocument());
         const adminMenu = getByTestId("appnavbar-admin-dropdown");
         expect(adminMenu).toBeInTheDocument();        
     });


### PR DESCRIPTION
In this PR, we changed the welcome message in the Navbar to be the user's name instead of their email to make the UI more personalized and enhance user experience. 

![image](https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-2/assets/72901128/0cbf0d76-7332-407d-96f3-a5257b14f893)