### PR TITLE
Leon chatroom backend entity and POST/GET APIs

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
@@ -20,7 +20,6 @@ import edu.ucsb.cs156.gauchoride.entities.DriverChat;
 import edu.ucsb.cs156.gauchoride.entities.User;
 import edu.ucsb.cs156.gauchoride.repositories.DriverChatRepository;
 import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
-import edu.ucsb.cs156.gauchoride.errors.IllegalRequestException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
@@ -75,7 +75,7 @@ public class DriverChatController extends ApiController {
 
         if (!currentUser.equals(sender)){
             throw new IllegalRequestException();
-            // throw new IllegalArgumentException("some shit");
+            // throw new IllegalArgumentException("some good stuff");
         }
 
         DriverChat savedMessage = driverChatRepository.save(driverChat);

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
@@ -2,10 +2,8 @@ package edu.ucsb.cs156.gauchoride.controllers;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -19,7 +17,6 @@ import org.springframework.data.domain.PageRequest;
 import javax.validation.Valid;
 
 import edu.ucsb.cs156.gauchoride.entities.DriverChat;
-import edu.ucsb.cs156.gauchoride.entities.User;
 import edu.ucsb.cs156.gauchoride.repositories.DriverChatRepository;
 import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
 import io.swagger.annotations.Api;
@@ -44,7 +41,6 @@ public class DriverChatController extends ApiController {
         return driverChatRepository.findAll();
     }
 
-
     @ApiOperation(value = "Get the latest N messages based on query parameters")
     @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_DRIVER')")
     @GetMapping("/list")
@@ -54,7 +50,6 @@ public class DriverChatController extends ApiController {
         Pageable pageable = PageRequest.of(0, limit);
         return driverChatRepository.findAllByOrderByTimeStampDesc(pageable);
     }
-
 
     @ApiOperation(value = "Get a single chat message")
     @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_DRIVER')")
@@ -66,7 +61,6 @@ public class DriverChatController extends ApiController {
         return message;
     }
 
-
     @ApiOperation(value="Create a new chat message")
     @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_DRIVER')")
     @PostMapping("/post")
@@ -76,76 +70,5 @@ public class DriverChatController extends ApiController {
 
         DriverChat savedMessage = driverChatRepository.save(driverChat);
         return savedMessage;
-    }
-
-
-    @ApiOperation(value="Update a driver's message")
-    @PreAuthorize("hasRole('ROLE_DRIVER')")
-    @PutMapping("")
-    public DriverChat updateMessageByDriver(
-        @ApiParam("Id") @RequestParam Long id,
-        @ApiParam("messageContent") @RequestParam String messageContent
-    ) {
-        User currentUser = getCurrentUser().getUser();
-        DriverChat message = driverChatRepository.findByIdAndSender(id, currentUser)
-                    .orElseThrow(()->new EntityNotFoundException(DriverChat.class, id));
-        
-        message.setMessageContent(messageContent);
-        driverChatRepository.save(message);
-        return message;
-    }
-
-
-    @ApiOperation(value="Update a driver's message(admin can edit anyone's messages)")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PutMapping("admin")
-    public DriverChat updateMessageByAdmin(
-        @ApiParam("Id") @RequestParam Long id,
-        @ApiParam("messageContent") @RequestParam String messageContent
-    ) {
-        DriverChat message = driverChatRepository.findById(id)
-                .orElseThrow(()->new EntityNotFoundException(DriverChat.class, id));
-        
-        message.setMessageContent(messageContent);
-        driverChatRepository.save(message);
-        return message;
-    }
-
-
-    @ApiOperation(value="Delete a chat message if it belongs to you")
-    @PreAuthorize("hasRole('ROLE_DRIVER')")
-    @DeleteMapping()
-    public Object deleteMessageByDriver(
-        @ApiParam("id") @RequestParam Long id
-    ) {
-        User currentUser = getCurrentUser().getUser();
-        DriverChat message = driverChatRepository.findByIdAndSender(id, currentUser)
-        .orElseThrow(()->new EntityNotFoundException(DriverChat.class, id));
-
-        driverChatRepository.delete(message);
-        return genericMessage("Message with id %s deleted.".formatted(id));
-    }
-
-
-    @ApiOperation(value="Delete a chat message")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @DeleteMapping("/admin")
-    public Object deleteMessageByAdmin(
-        @ApiParam("id") @RequestParam Long id
-    ) {
-        DriverChat message = driverChatRepository.findById(id)
-        .orElseThrow(()->new EntityNotFoundException(DriverChat.class, id));
-
-        driverChatRepository.delete(message);
-        return genericMessage("Message with id %s deleted.".formatted(id));
-    }
-
-
-    @ApiOperation(value="Delete all chat messages")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @DeleteMapping("/all")
-    public Object deleteAllMessages() {
-        driverChatRepository.deleteAll();
-        return genericMessage("All messages have been deleted.");
     }
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
@@ -14,8 +14,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageRequest;
 
-import javax.validation.Valid;
-
 import edu.ucsb.cs156.gauchoride.entities.DriverChat;
 import edu.ucsb.cs156.gauchoride.entities.User;
 import edu.ucsb.cs156.gauchoride.repositories.DriverChatRepository;
@@ -23,6 +21,8 @@ import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+
+import java.time.LocalDateTime;
 
 @Api(description= "Driver chat information")
 @RequestMapping("/api/driverchats")
@@ -66,12 +66,16 @@ public class DriverChatController extends ApiController {
     @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_DRIVER')")
     @PostMapping("/post")
     public DriverChat postNewMessage(
-        @RequestBody @Valid DriverChat driverChat
+        @RequestBody String messageContent
     )  throws JsonProcessingException {
 
         User currentUser = getCurrentUser().getUser();
-        driverChat.setSender(currentUser);
+        DriverChat chatMessage = DriverChat.builder()
+            .sender(currentUser)
+            .messageContent(messageContent)
+            .timeStamp(LocalDateTime.now())
+            .build();
       
-        return  driverChatRepository.save(driverChat);
+        return  driverChatRepository.save(chatMessage);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
@@ -1,0 +1,151 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+
+import javax.validation.Valid;
+
+import edu.ucsb.cs156.gauchoride.entities.DriverChat;
+import edu.ucsb.cs156.gauchoride.entities.User;
+import edu.ucsb.cs156.gauchoride.repositories.DriverChatRepository;
+import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+
+@Api(description= "Driver chat information")
+@RequestMapping("/api/driverchats")
+@RestController
+public class DriverChatController extends ApiController {
+
+    @Autowired
+    DriverChatRepository driverChatRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @ApiOperation(value = "Get a list of all chat message")
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_DRIVER')")
+    @GetMapping("/all")
+    public Iterable<DriverChat> getAllMessages() {
+        return driverChatRepository.findAll();
+    }
+
+
+    @ApiOperation(value = "Get the latest N messages based on query parameters")
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_DRIVER')")
+    @GetMapping("/list")
+    public Iterable<DriverChat> getRecentMessage(
+        @ApiParam("limit") @RequestParam int limit
+    ) {
+        Pageable pageable = PageRequest.of(0, limit);
+        return driverChatRepository.findAllByOrderByTimeStampDesc(pageable);
+    }
+
+
+    @ApiOperation(value = "Get a single chat message")
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_DRIVER')")
+    @GetMapping("")
+    public DriverChat getMessageById(@ApiParam("id") @RequestParam Long id) {
+        DriverChat message =  driverChatRepository.findById(id)
+        .orElseThrow(()->new EntityNotFoundException(DriverChat.class, id));
+
+        return message;
+    }
+
+
+    @ApiOperation(value="Create a new chat message")
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_DRIVER')")
+    @PostMapping("/post")
+    public DriverChat postNewMessage(
+        @RequestBody @Valid DriverChat driverChat
+    )  throws JsonProcessingException {
+
+        DriverChat savedMessage = driverChatRepository.save(driverChat);
+        return savedMessage;
+    }
+
+
+    @ApiOperation(value="Update a driver's message")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @PutMapping("")
+    public DriverChat updateMessageByDriver(
+        @ApiParam("Id") @RequestParam Long id,
+        @ApiParam("messageContent") @RequestParam String messageContent
+    ) {
+        User currentUser = getCurrentUser().getUser();
+        DriverChat message = driverChatRepository.findByIdAndSender(id, currentUser)
+                    .orElseThrow(()->new EntityNotFoundException(DriverChat.class, id));
+        
+        message.setMessageContent(messageContent);
+        driverChatRepository.save(message);
+        return message;
+    }
+
+
+    @ApiOperation(value="Update a driver's message(admin can edit anyone's messages)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("admin")
+    public DriverChat updateMessageByAdmin(
+        @ApiParam("Id") @RequestParam Long id,
+        @ApiParam("messageContent") @RequestParam String messageContent
+    ) {
+        DriverChat message = driverChatRepository.findById(id)
+                .orElseThrow(()->new EntityNotFoundException(DriverChat.class, id));
+        
+        message.setMessageContent(messageContent);
+        driverChatRepository.save(message);
+        return message;
+    }
+
+
+    @ApiOperation(value="Delete a chat message if it belongs to you")
+    @PreAuthorize("hasRole('ROLE_DRIVER')")
+    @DeleteMapping()
+    public Object deleteMessageByDriver(
+        @ApiParam("id") @RequestParam Long id
+    ) {
+        User currentUser = getCurrentUser().getUser();
+        DriverChat message = driverChatRepository.findByIdAndSender(id, currentUser)
+        .orElseThrow(()->new EntityNotFoundException(DriverChat.class, id));
+
+        driverChatRepository.delete(message);
+        return genericMessage("Message with id %s deleted.".formatted(id));
+    }
+
+
+    @ApiOperation(value="Delete a chat message")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/admin")
+    public Object deleteMessageByAdmin(
+        @ApiParam("id") @RequestParam Long id
+    ) {
+        DriverChat message = driverChatRepository.findById(id)
+        .orElseThrow(()->new EntityNotFoundException(DriverChat.class, id));
+
+        driverChatRepository.delete(message);
+        return genericMessage("Message with id %s deleted.".formatted(id));
+    }
+
+
+    @ApiOperation(value="Delete all chat messages")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/all")
+    public Object deleteAllMessages() {
+        driverChatRepository.deleteAll();
+        return genericMessage("All messages have been deleted.");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
@@ -75,6 +75,7 @@ public class DriverChatController extends ApiController {
 
         if (!currentUser.equals(sender)){
             throw new IllegalRequestException();
+            // throw new IllegalArgumentException("some shit");
         }
 
         DriverChat savedMessage = driverChatRepository.save(driverChat);

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
@@ -17,8 +17,10 @@ import org.springframework.data.domain.PageRequest;
 import javax.validation.Valid;
 
 import edu.ucsb.cs156.gauchoride.entities.DriverChat;
+import edu.ucsb.cs156.gauchoride.entities.User;
 import edu.ucsb.cs156.gauchoride.repositories.DriverChatRepository;
 import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
+import edu.ucsb.cs156.gauchoride.errors.IllegalRequestException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -67,6 +69,13 @@ public class DriverChatController extends ApiController {
     public DriverChat postNewMessage(
         @RequestBody @Valid DriverChat driverChat
     )  throws JsonProcessingException {
+
+        User currentUser = getCurrentUser().getUser();
+        User sender = driverChat.getSender();
+
+        if (!currentUser.equals(sender)){
+            throw new IllegalRequestException();
+        }
 
         DriverChat savedMessage = driverChatRepository.save(driverChat);
         return savedMessage;

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatController.java
@@ -47,7 +47,7 @@ public class DriverChatController extends ApiController {
     @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_DRIVER')")
     @GetMapping("/list")
     public Iterable<DriverChat> getRecentMessage(
-        @ApiParam("limit") @RequestParam int limit
+        @ApiParam(name = "limit", required = true, example ="100", value="an integer, representing how many messages to query", type="Long") @RequestParam int limit
     ) {
         Pageable pageable = PageRequest.of(0, limit);
         return driverChatRepository.findAllByOrderByTimeStampDesc(pageable);
@@ -56,7 +56,7 @@ public class DriverChatController extends ApiController {
     @ApiOperation(value = "Get a single chat message")
     @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_DRIVER')")
     @GetMapping("")
-    public DriverChat getMessageById(@ApiParam("id") @RequestParam Long id) {
+    public DriverChat getMessageById(@ApiParam(name = "id", required = true, example="15", value="id of the message", type="Long") @RequestParam Long id) {
         DriverChat message =  driverChatRepository.findById(id)
         .orElseThrow(()->new EntityNotFoundException(DriverChat.class, id));
 
@@ -71,14 +71,8 @@ public class DriverChatController extends ApiController {
     )  throws JsonProcessingException {
 
         User currentUser = getCurrentUser().getUser();
-        User sender = driverChat.getSender();
-
-        if (!currentUser.equals(sender)){
-            throw new IllegalRequestException();
-            // throw new IllegalArgumentException("some good stuff");
-        }
-
-        DriverChat savedMessage = driverChatRepository.save(driverChat);
-        return savedMessage;
+        driverChat.setSender(currentUser);
+      
+        return  driverChatRepository.save(driverChat);
     }
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/DriverChat.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/DriverChat.java
@@ -1,0 +1,40 @@
+package edu.ucsb.cs156.gauchoride.entities;
+
+import java.time.LocalDateTime;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.AccessLevel;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.validation.constraints.NotNull;
+import javax.persistence.JoinColumn;
+import javax.persistence.Index;
+import javax.persistence.Table;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity(name = "driverchats")
+@Table(name = "driverchats",indexes = @Index(name = "ts_index", columnList = "timeStamp DESC"))
+public class DriverChat {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @NotNull
+    private LocalDateTime timeStamp;
+
+    @NotNull
+    private String messageContent;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User sender;
+}

--- a/src/main/java/edu/ucsb/cs156/gauchoride/errors/IllegalRequestException.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/errors/IllegalRequestException.java
@@ -1,0 +1,10 @@
+package edu.ucsb.cs156.gauchoride.errors;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class IllegalRequestException extends RuntimeException {
+    public IllegalRequestException() {
+        super("HTTP request cannot be processed.");
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/gauchoride/errors/IllegalRequestException.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/errors/IllegalRequestException.java
@@ -1,7 +1,0 @@
-package edu.ucsb.cs156.gauchoride.errors;
-
-public class IllegalRequestException extends RuntimeException {
-    public IllegalRequestException() {
-        super("HTTP request cannot be processed.");
-    }
-}

--- a/src/main/java/edu/ucsb/cs156/gauchoride/errors/IllegalRequestException.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/errors/IllegalRequestException.java
@@ -1,8 +1,5 @@
 package edu.ucsb.cs156.gauchoride.errors;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ResponseStatus(HttpStatus.BAD_REQUEST)
 public class IllegalRequestException extends RuntimeException {
     public IllegalRequestException() {
         super("HTTP request cannot be processed.");

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/DriverChatRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/DriverChatRepository.java
@@ -1,0 +1,16 @@
+package edu.ucsb.cs156.gauchoride.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+import edu.ucsb.cs156.gauchoride.entities.DriverChat;
+import edu.ucsb.cs156.gauchoride.entities.User;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface DriverChatRepository extends CrudRepository<DriverChat, Long> {
+    List<DriverChat> findAllByOrderByTimeStampDesc(Pageable pageable);
+    Optional<DriverChat> findByIdAndSender(long id, User user);
+}

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatControllerTests.java
@@ -287,7 +287,7 @@ public class DriverChatControllerTests extends ControllerTestCase {
         //     .characterEncoding("utf-8")
         //     .content(requestBody).with(csrf()))
         //     .andExpect(status().isInternalServerError());
-        // }).hasCause(new IllegalArgumentException()).hasMessageContaining("some shit");
+        // }).hasCause(new IllegalArgumentException()).hasMessageContaining("some good stuff");
 
         // Assert
         verify(driverChatRepository, times(0)).save(chat);

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatControllerTests.java
@@ -1,0 +1,257 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.junit.jupiter.api.Test;
+
+import edu.ucsb.cs156.gauchoride.ControllerTestCase;
+import edu.ucsb.cs156.gauchoride.entities.DriverChat;
+import edu.ucsb.cs156.gauchoride.repositories.DriverChatRepository;
+import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+import edu.ucsb.cs156.gauchoride.entities.User;
+import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.http.MediaType;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@WebMvcTest(controllers = DriverChatController.class)
+@Import(TestConfig.class)
+public class DriverChatControllerTests extends ControllerTestCase {
+
+    @MockBean
+    DriverChatRepository driverChatRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+
+    // Test if user can access API endpoint when logged out
+    @Test
+    public void logged_out_user_cannot_get_all() throws Exception {
+        mockMvc.perform(get("/api/driverchats/all")).andExpect(status().is(403));
+    }
+
+    @Test 
+    public void logged_out_user_cannot_get_recent_chats() throws Exception {
+        mockMvc.perform(get("/api/driverchats/list?limit=5")).andExpect(status().is(403));
+    }
+
+    @Test
+    public void logged_out_user_cannot_get_by_id() throws Exception {
+        mockMvc.perform(get("/api/driverchats?id=2")).andExpect(status().is(403));
+    }
+
+    @Test 
+    public void logged_out_user_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/driverchats/post")).andExpect(status().is(403));
+    }
+
+
+    // Test user roles when user is logged in
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_user_cannot_get_all() throws Exception {
+        mockMvc.perform(get("/api/driverchats/all")).andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_user_cannot_list_recent_chats() throws Exception {
+        mockMvc.perform(get("/api/driverchats/list?limit=5")).andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_user_get_by_id() throws Exception {
+        mockMvc.perform(get("/api/driverchats?id=2")).andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_user_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/driverchats/post")).andExpect(status().is(403));
+    }
+
+    // Tests functionalities
+    @WithMockUser(roles = { "ADMIN", "DRIVER", "USER" })
+    @Test
+    public void logged_in_admin_or_driver_can_get_all() throws Exception {
+        mockMvc.perform(get("/api/driverchats/all")).andExpect(status().is(200));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "DRIVER", "USER" })
+    @Test
+    public void logged_in_admin_or_driver_can_get_all_messages() throws Exception {
+        // Setup
+        User currentUser = currentUserService.getCurrentUser().getUser();
+        User user1 = User.builder().id(99L).build();
+        User user2 = User.builder().id(100L).build();
+        LocalDateTime ldt1 = LocalDateTime.parse("2023-05-27T00:00:00");
+        LocalDateTime ldt2 = LocalDateTime.parse("2023-05-26T00:00:00");
+        LocalDateTime ldt3 = LocalDateTime.parse("2023-05-25T00:00:00");
+
+        DriverChat chat1 = DriverChat.builder()
+                    .messageContent("Hey Can you pick me up now?")
+                    .sender(currentUser)
+                    .timeStamp(ldt1)
+                    .build();
+
+        DriverChat chat2 = DriverChat.builder()
+        .messageContent("I need to be picked up at 1:15pm.")
+        .sender(user1)
+        .timeStamp(ldt2)
+        .build();
+
+        DriverChat chat3 = DriverChat.builder()
+        .messageContent("I cancelled my ride.")
+        .sender(user2)
+        .timeStamp(ldt3)
+        .build();
+
+        ArrayList<DriverChat> expectedMessages = new ArrayList<>();
+        expectedMessages.addAll(Arrays.asList(chat1, chat2, chat3));
+        when(driverChatRepository.findAll()).thenReturn(expectedMessages);
+
+         // Act
+         MvcResult response = mockMvc.perform(get("/api/driverchats/all"))
+         .andExpect(status().isOk()).andReturn();
+
+        // Assert
+
+        verify(driverChatRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedMessages);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "DRIVER", "USER" })
+    @Test
+    public void logged_in_admin_or_driver_can_get_recent_chats() throws Exception {
+        mockMvc.perform(get("/api/driverchats/list?limit=5")).andExpect(status().is(200));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "DRIVER", "USER" })
+    @Test
+    public void logged_in_admin_or_driver_can_get_recent_chats_with_order() throws Exception {
+        // Setup
+        User currentUser = currentUserService.getCurrentUser().getUser();
+        User user1 = User.builder().id(99L).build();
+        LocalDateTime ldt1 = LocalDateTime.parse("2023-05-27T00:00:00");
+        LocalDateTime ldt2 = LocalDateTime.parse("2023-05-26T00:00:00");
+
+        DriverChat chat1 = DriverChat.builder()
+                    .messageContent("Hey Can you pick me up now?")
+                    .sender(currentUser)
+                    .timeStamp(ldt1)
+                    .build();
+
+        DriverChat chat2 = DriverChat.builder()
+        .messageContent("I need to be picked up at 1:15pm.")
+        .sender(user1)
+        .timeStamp(ldt2)
+        .build();
+
+        ArrayList<DriverChat> expectedMessages = new ArrayList<>();
+        expectedMessages.addAll(Arrays.asList(chat1, chat2));
+
+        Pageable pageable = PageRequest.of(0, 2);
+        when(driverChatRepository.findAllByOrderByTimeStampDesc(pageable)).thenReturn(expectedMessages);
+
+        MvcResult response = mockMvc.perform(get("/api/driverchats/list?limit=2"))
+         .andExpect(status().isOk()).andReturn();
+
+        verify(driverChatRepository, times(1)).findAllByOrderByTimeStampDesc(pageable);
+        String expectedJson = mapper.writeValueAsString(expectedMessages);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "DRIVER", "USER" })
+    @Test
+    public void logged_in_driver_can_get_by_id_when_the_id_exists() throws Exception {
+        // Setup
+        User currentUser = currentUserService.getCurrentUser().getUser();
+        LocalDateTime ldt = LocalDateTime.parse("2023-05-27T00:00:00");
+        DriverChat chat = DriverChat.builder()
+                    .messageContent("Hey Can you pick me up now?")
+                    .sender(currentUser)
+                    .timeStamp(ldt)
+                    .build();
+        
+        when(driverChatRepository.findById(eq(1L))).thenReturn(Optional.of(chat));
+
+        // Act
+        MvcResult response = mockMvc.perform(get("/api/driverchats?id=1")).andExpect(status().isOk()).andReturn();
+
+
+        // Assert
+        verify(driverChatRepository, times(1)).findById(1L);
+        String expectedJson = mapper.writeValueAsString(chat);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "DRIVER", "USER" })
+    @Test
+    public void logged_in_driver_cannot_get_by_id_when_the_id_does_not_exists() throws Exception {
+        // Setup
+        when(driverChatRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+        // Act
+        MvcResult response = mockMvc.perform(get("/api/driverchats?id=1")).andExpect(status().isNotFound()).andReturn();
+
+        // Assert
+        verify(driverChatRepository, times(1)).findById(1L);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("EntityNotFoundException", json.get("type"));
+        assertEquals("DriverChat with id 1 not found", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "DRIVER", "USER" })
+    @Test
+    public void logged_in_admin_and_driver_can_post_message() throws Exception {
+        // Setup
+        User currentUser = currentUserService.getCurrentUser().getUser();
+        LocalDateTime ldt = LocalDateTime.parse("2023-05-27T00:00:00");
+        DriverChat chat = DriverChat.builder()
+                    .messageContent("Hey Can you pick me up now?")
+                    .sender(currentUser)
+                    .timeStamp(ldt)
+                    .build();
+
+        String requestBody = mapper.writeValueAsString(chat);
+        when(driverChatRepository.save(chat)).thenReturn(chat);
+
+        // Act
+        MvcResult response = mockMvc.perform(post("/api/driverchats/post")
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding("utf-8")
+        .content(requestBody).with(csrf())).andExpect(status().isOk()).andReturn();
+
+        // Assert
+        verify(driverChatRepository, times(1)).save(chat);
+        String expectedJson = mapper.writeValueAsString(chat);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverChatControllerTests.java
@@ -281,6 +281,13 @@ public class DriverChatControllerTests extends ControllerTestCase {
             .content(requestBody).with(csrf()))
             .andExpect(status().isInternalServerError());
         }).hasCause(new IllegalRequestException()).hasMessageContaining("HTTP request cannot be processed.");
+        // assertThatThrownBy(() -> {
+        //     mockMvc.perform(post("/api/driverchats/post")
+        //     .contentType(MediaType.APPLICATION_JSON)
+        //     .characterEncoding("utf-8")
+        //     .content(requestBody).with(csrf()))
+        //     .andExpect(status().isInternalServerError());
+        // }).hasCause(new IllegalArgumentException()).hasMessageContaining("some shit");
 
         // Assert
         verify(driverChatRepository, times(0)).save(chat);


### PR DESCRIPTION
DESCRIPTION:
add a new table called driverChat in the backend for driver chat functions, and add GET, POST APIs that users can use to retrieve messages from the database and post new messages to the database.
SOLUTION:
1. add driver chat entity, and All GET and POST methods.
2. add documentation for API parameters.
3. add related unit tests to endpoints.
**Before:**
![Screenshot 2023-05-30 at 10 42 55 PM](https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-2/assets/59664884/e9bd62f6-dd73-4e0d-bb35-63251112040d)
**After:**
<img width="756" alt="Screenshot 2023-06-04 at 12 55 08 PM" src="https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-2/assets/59664884/fe9a28f7-141e-41f7-bd0b-9e2726034132">

