### PR TITLE
pc - fix workflows 13 and 14 for pitest

### DIFF
--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -23,6 +23,19 @@ jobs:
       with:
          distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
          java-version-file: ./.java-version
+    - name: Get PR number
+      id: get-pr-num
+      run: |
+        echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"
+        pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        echo "pr_number=${pr_number}" 
+        if [[ "${pr_number}" == "null" ]]; then
+          echo "This is not a PR"
+          pr_number="main"
+        fi
+        echo "pr_number=${pr_number}" >> "$GITHUB_ENV"
+  
+
     - name: Figure out branch name
       id: get-branch-name
       run: | 
@@ -40,17 +53,11 @@ jobs:
       uses: dawidd6/action-download-artifact@v2.27.0
       with:
         github_token: ${{secrets.GITHUB_TOKEN}}
-        branch: ${{ env.branch_name }}
-        name: pitest-${{env.branch_name}}-history.bin
+        branch: ${{ env.pr_number}}
+        name: pitest-${{env.pr_number}}-history.bin
         path: target/pit-history
         check_artifacts: true
         if_no_artifact_found: warn
-    - name: Copy artifact to pit-history/history.bin # specified in pom.xml as historyInputFile
-      continue-on-error: true
-      run: |
-        historyFile=target/pit-history/pitest-main-history.bin
-        [ -f "$historyFile" ] && cp $historyFile target/pit-history/history.bin
-
     - name: Build with Maven
       run: mvn -B test 
     - name: Pitest
@@ -68,28 +75,17 @@ jobs:
         name: pitest
         path: target/pit-reports/* 
 
-    - name: Get PR number
-      id: get-pr-num
-      run: |
-        echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"
-        pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-        echo "pr_number=${pr_number}" 
-        echo "pr_number=${pr_number}" >> "$GITHUB_ENV"
-
     - name: Set path for github pages deploy when there is a PR num
-      if: ${{ env.pr_number != 'null' }}
+      if: always() # always upload artifacts, even if tests fail
       run: |
-        prefix="prs/${pr_number}/"
+        if [ "${{env.pr_number }}" = "main" ]; then
+            prefix=""
+        else
+            prefix="prs/${{ env.pr_number }}/"
+        fi
         echo "prefix=${prefix}"
         echo "prefix=${prefix}" >> "$GITHUB_ENV"
-    
-    - name: Set path for github pages deploy when there is NOT a PR num
-      if: ${{ env.pr_number == 'null' }}
-      run: |
-        prefix=""
-        echo "prefix=${prefix}"
-        echo "prefix=${prefix}" >> "$GITHUB_ENV"
-
+     
     - name: Deploy 🚀
       if: always() # always upload artifacts, even if tests fail
       uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -5,8 +5,6 @@ name: "14-backend-pitest: Java Mutation Testing (Pitest)"
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths: [src/**, pom.xml, lombok.config]
   push:
     branches: [ main ]
     paths: [src/**, pom.xml, lombok.config]
@@ -18,18 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3.5.2
-    - name: Figure out branch name
-      id: get-branch-name
-      run: | 
-          GITHUB_HEAD_REF="${GITHUB_HEAD_REF}"
-          echo GITHUB_HEAD_REF=${GITHUB_HEAD_REF}
-          GITHUB_REF_CLEANED=${GITHUB_REF/refs\/heads\//}
-          echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
-          GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED//\//-}
-          echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
-          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_CLEANED}}"
-          echo "branch_name=${BRANCH}"
-          echo "branch_name=${BRANCH}" >> "$GITHUB_ENV"    
+     
     - name: Set up Java (version from .java-version file)
       uses: actions/setup-java@v3
       with:
@@ -39,8 +26,8 @@ jobs:
       run: mvn -B test 
     
     # Note that we DO NOT download history in this job;
-    # this job is intended as a "reset" of the history each time the 
-    # main branch changes
+    # this job is intended as a "reset" of the history for the main
+    # branch each time the main branch changes
 
     - name: Pitest
       run: mvn test org.pitest:pitest-maven:mutationCoverage -DmutationThreshold=100 
@@ -48,7 +35,7 @@ jobs:
       if: always() # always upload artifacts, even if tests fail
       uses: actions/upload-artifact@v3.1.2
       with:
-        name: pitest-${{env.branch_name}}-history.bin
+        name: pitest-main-history.bin
         path: target/pit-history/history.bin
     - name: Upload Pitest to Artifacts
       if: always() # always upload artifacts, even if tests fail
@@ -56,29 +43,6 @@ jobs:
       with:
         name: pitest
         path: target/pit-reports/* 
-
-    - name: Get PR number
-      id: get-pr-num
-      run: |
-        echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"
-        pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-        echo "pr_number=${pr_number}" 
-        echo "pr_number=${pr_number}" >> "$GITHUB_ENV"
-
-    - name: Set path for github pages deploy when there is a PR num
-      if: ${{ env.pr_number != 'null' }}
-      run: |
-        prefix="prs/${pr_number}/"
-        echo "prefix=${prefix}"
-        echo "prefix=${prefix}" >> "$GITHUB_ENV"
-    
-    - name: Set path for github pages deploy when there is NOT a PR num
-      if: ${{ env.pr_number == 'null' }}
-      run: |
-        prefix=""
-        echo "prefix=${prefix}"
-        echo "prefix=${prefix}" >> "$GITHUB_ENV"
-
     - name: Deploy 🚀
       if: always() # always upload artifacts, even if tests fail
       uses: JamesIves/github-pages-deploy-action@v4
@@ -86,4 +50,4 @@ jobs:
         branch: gh-pages # The branch the action should deploy to.
         folder: target/pit-reports # The folder where the files we want to publish are located
         clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: ${{env.prefix}}pitest # The folder that we serve our files from
+        target-folder: pitest # The folder that we serve our files from


### PR DESCRIPTION
In this PR, we update workflows 13 and 14 so that they work as intended:
* PR 13 uses the incremental results and publishes to github pages for either the main branch or the PR
* PR 14 only runs on a push the main branch, and updates only the main (and does not use prior incremental results.)