### PR TITLE
jessica add controller files for driver shift table backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverShiftController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverShiftController.java
@@ -1,0 +1,53 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.ucsb.cs156.gauchoride.entities.User;
+import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+import edu.ucsb.cs156.gauchoride.entities.DriverShift;
+import edu.ucsb.cs156.gauchoride.repositories.DriverShiftRepository;
+import edu.ucsb.cs156.gauchoride.entities.DriverShift.Weekday;
+
+import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import org.springframework.web.bind.annotation.RequestBody;
+import javax.validation.Valid;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+
+@Api(description = "Driver shift information")
+@RequestMapping("/api/drivershifts")
+@RestController
+public class DriverShiftController extends ApiController {
+    @Autowired
+    DriverShiftRepository driverShiftRepository;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    @ApiOperation(value = "Get a list of all driver shifts")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/all")
+    public Iterable<DriverShift> getAllDriverShifts() {
+        Iterable<DriverShift> driverShifts = driverShiftRepository.findAll();
+        return driverShifts;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverShiftController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriverShiftController.java
@@ -44,7 +44,7 @@ public class DriverShiftController extends ApiController {
     ObjectMapper mapper;
 
     @ApiOperation(value = "Get a list of all driver shifts")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER')")
     @GetMapping("/all")
     public Iterable<DriverShift> getAllDriverShifts() {
         Iterable<DriverShift> driverShifts = driverShiftRepository.findAll();

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/DriverShift.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/DriverShift.java
@@ -12,31 +12,30 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Data
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+//(access = AccessLevel.PROTECTED)
 @Builder
-@Entity(name = "shifts")
+@Entity(name = "driverShifts")
 public class DriverShift {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
-
-  private Weekday weekday;
-
-  @JsonFormat(pattern = "HH:mm:ss", shape = JsonFormat.Shape.STRING)
-  private LocalDateTime startShiftTime;
-
-  @JsonFormat(pattern = "HH:mm:ss", shape = JsonFormat.Shape.STRING)
-  private LocalDateTime endShiftTime;
-
+  
   @ManyToOne
   private User driver;
 
   @ManyToOne
   private User backupDriver;
+
+  private Weekday weekday;
+
+  private LocalTime startTime;
+
+  private LocalTime endTime;
 
   public enum Weekday {
     Monday, Tuesday, Wednesday, Thursday, Friday;

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/DriverShift.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/DriverShift.java
@@ -1,0 +1,46 @@
+package edu.ucsb.cs156.gauchoride.entities;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.AccessLevel;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Entity(name = "shifts")
+public class DriverShift {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private Weekday weekday;
+
+  @JsonFormat(pattern = "HH:mm:ss", shape = JsonFormat.Shape.STRING)
+  private LocalDateTime startShiftTime;
+
+  @JsonFormat(pattern = "HH:mm:ss", shape = JsonFormat.Shape.STRING)
+  private LocalDateTime endShiftTime;
+
+  @ManyToOne
+  private User driver;
+
+  @ManyToOne
+  private User backupDriver;
+
+  public enum Weekday {
+    Monday, Tuesday, Wednesday, Thursday, Friday;
+  }
+}
+
+

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/DriverShift.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/DriverShift.java
@@ -16,8 +16,7 @@ import java.time.LocalTime;
 
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
-//(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Entity(name = "driverShifts")
 public class DriverShift {

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/DriverShiftRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/DriverShiftRepository.java
@@ -4,12 +4,12 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import edu.ucsb.cs156.gauchoride.entities.DriverShift;
+import edu.ucsb.cs156.gauchoride.entities.User;
 
 import java.util.Optional;
 
-
 @Repository
 public interface DriverShiftRepository extends CrudRepository<DriverShift, Long> {
-    Optional<DriverShift> findByDriver(String driver);
+    Optional<DriverShift> findByDriver(User driver);
 }
   

--- a/src/main/java/edu/ucsb/cs156/gauchoride/repositories/DriverShiftRepository.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/repositories/DriverShiftRepository.java
@@ -1,0 +1,15 @@
+package edu.ucsb.cs156.gauchoride.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.gauchoride.entities.DriverShift;
+
+import java.util.Optional;
+
+
+@Repository
+public interface DriverShiftRepository extends CrudRepository<DriverShift, Long> {
+    Optional<DriverShift> findByDriver(String driver);
+}
+  

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverShiftControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverShiftControllerTests.java
@@ -1,0 +1,109 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import edu.ucsb.cs156.gauchoride.ControllerTestCase;
+import edu.ucsb.cs156.gauchoride.entities.User;
+import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+import edu.ucsb.cs156.gauchoride.entities.DriverShift;
+import edu.ucsb.cs156.gauchoride.repositories.DriverShiftRepository;
+import edu.ucsb.cs156.gauchoride.entities.DriverShift.Weekday;
+import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalTime;
+
+@WebMvcTest(controllers = DriverShiftController.class)
+@Import(TestConfig.class)
+public class DriverShiftControllerTests extends ControllerTestCase {
+    @MockBean
+    DriverShiftRepository driverShiftRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Test
+    public void logged_out_users_cannot_get_all() throws Exception {
+        mockMvc.perform(get("/api/drivershifts/all"))
+                .andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_regular_user_cannot_get_all() throws Exception {
+        mockMvc.perform(get("/api/drivershifts/all")).andExpect(status().is(403));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "DRIVER", "USER" })
+    @Test
+    public void logged_in_admin_or_driver_can_get_all_shifts() throws Exception {
+        mockMvc.perform(get("/api/drivershifts/all")).andExpect(status().is(200));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "DRIVER", "USER" })
+    @Test
+    public void logged_in_admin_or_driver_can_get_correct_shift_list() throws Exception {
+        // arrange
+        User driver1 = User.builder().id(1L).build();
+        User backup1 = User.builder().id(2L).build();
+        User driver2 = User.builder().id(3L).build();
+        User backup2 = User.builder().id(4L).build();
+
+        LocalTime start1 = LocalTime.parse("00:00:00");
+        LocalTime end1 = LocalTime.parse("12:34:56");
+        LocalTime start2 = LocalTime.parse("11:11:11");
+        LocalTime end2 = LocalTime.parse("22:22:22");
+
+        DriverShift driverShift1 = DriverShift.builder()
+                .driver(driver1)
+                .backupDriver(backup1)
+                .startTime(start1)
+                .endTime(end1)
+                .weekday(Weekday.Friday)
+                .build();
+
+        DriverShift driverShift2 = DriverShift.builder()
+                .driver(driver2)
+                .backupDriver(backup2)
+                .startTime(start2)
+                .endTime(end2)
+                .weekday(Weekday.Monday)
+                .build();
+
+        ArrayList<DriverShift> expectedDriverShift = new ArrayList<>();
+        expectedDriverShift.addAll(Arrays.asList(driverShift1, driverShift2));
+
+        when(driverShiftRepository.findAll()).thenReturn(expectedDriverShift);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/drivershifts/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(driverShiftRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedDriverShift);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverShiftControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriverShiftControllerTests.java
@@ -55,15 +55,67 @@ public class DriverShiftControllerTests extends ControllerTestCase {
         mockMvc.perform(get("/api/drivershifts/all")).andExpect(status().is(403));
     }
 
-    @WithMockUser(roles = { "ADMIN", "DRIVER", "USER" })
+    @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
-    public void logged_in_admin_or_driver_can_get_all_shifts() throws Exception {
+    public void logged_in_admin_can_get_all_shifts() throws Exception {
         mockMvc.perform(get("/api/drivershifts/all")).andExpect(status().is(200));
     }
 
-    @WithMockUser(roles = { "ADMIN", "DRIVER", "USER" })
+    @WithMockUser(roles = { "DRIVER", "USER" })
     @Test
-    public void logged_in_admin_or_driver_can_get_correct_shift_list() throws Exception {
+    public void logged_in__driver_can_get_all_shifts() throws Exception {
+        mockMvc.perform(get("/api/drivershifts/all")).andExpect(status().is(200));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void logged_in_admin_can_get_correct_shift_list() throws Exception {
+        // arrange
+        User driver1 = User.builder().id(1L).build();
+        User backup1 = User.builder().id(2L).build();
+        User driver2 = User.builder().id(3L).build();
+        User backup2 = User.builder().id(4L).build();
+
+        LocalTime start1 = LocalTime.parse("00:00:00");
+        LocalTime end1 = LocalTime.parse("12:34:56");
+        LocalTime start2 = LocalTime.parse("11:11:11");
+        LocalTime end2 = LocalTime.parse("22:22:22");
+
+        DriverShift driverShift1 = DriverShift.builder()
+                .driver(driver1)
+                .backupDriver(backup1)
+                .startTime(start1)
+                .endTime(end1)
+                .weekday(Weekday.Friday)
+                .build();
+
+        DriverShift driverShift2 = DriverShift.builder()
+                .driver(driver2)
+                .backupDriver(backup2)
+                .startTime(start2)
+                .endTime(end2)
+                .weekday(Weekday.Monday)
+                .build();
+
+        ArrayList<DriverShift> expectedDriverShift = new ArrayList<>();
+        expectedDriverShift.addAll(Arrays.asList(driverShift1, driverShift2));
+
+        when(driverShiftRepository.findAll()).thenReturn(expectedDriverShift);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/drivershifts/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(driverShiftRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedDriverShift);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "DRIVER", "USER" })
+    @Test
+    public void logged_in_driver_can_get_correct_shift_list() throws Exception {
         // arrange
         User driver1 = User.builder().id(1L).build();
         User backup1 = User.builder().id(2L).build();


### PR DESCRIPTION
In this PR, we added entity, repository, and controller files for the driver shift table backend. This issue is part of the "CRUD operations for Driver Shift table" feature.

The entity file for the Driver Shift database table includes the following fields:
driver and backupDriver of type User
weekday of type Weekday (enum for Monday, Tuesday, Wednesday, Thursday, Friday)
startTime and endTime of type LocalTime

The repository file for the Driver Shift database table includes the findByDriver() method, which takes an argument of type User for the driver and returns all shifts for that driver.

The controller file contains a function to get a list of all driver shifts and various tests for the driver shift table.

![image](https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-2/assets/72901128/04cbb7ed-d93a-4941-bd67-4d74336b349f)