### PR TITLE
Pc update workflows

### DIFF
--- a/.github/workflows/10-backend-unit.yml
+++ b/.github/workflows/10-backend-unit.yml
@@ -6,10 +6,10 @@ name: "10-backend-unit: Java Unit tests"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/10-backend-unit.yml]
   push:
     branches: [ main ]
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/10-backend-unit.yml]
 
 jobs:
   build:

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -6,10 +6,10 @@ name: "12-backend-jacoco: Java Test Coverage (Jacoco)"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/12-backend-jacoco.yml]
   push:
     branches: [ main ]
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/12-backend-jacoco.yml]
 
 jobs:
   build-jacoco-report:
@@ -24,34 +24,34 @@ jobs:
          distribution: semeru # See: https://github.com/actions/setup-java#supported-distributions
          java-version-file: ./.java-version
   
-    - name: Build with Maven
-      env:
-        TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
-      run: mvn -B test jacoco:report verify
-
     - name: Get PR number
       id: get-pr-num
       run: |
-         echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"
-         pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-         echo "pr_number=${pr_number}" 
-         echo "pr_number=${pr_number}" >> "$GITHUB_ENV"
+        echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"
+        pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        echo "pr_number=${pr_number}" 
+        if [[ "${pr_number}" == "null" ]]; then
+          echo "This is not a PR"
+          pr_number="main"
+        fi
+        echo "pr_number=${pr_number}" >> "$GITHUB_ENV"   
+
+    - name: Build with Maven
+      run: mvn -B test jacoco:report verify
 
     - name: Set path for github pages deploy when there is a PR num
-      if: ${{ env.pr_number != 'null' }}
+      if: always() # always upload artifacts, even if tests fail
       run: |
-        prefix="prs/${pr_number}/"
-        echo "prefix=${prefix}"
-        echo "prefix=${prefix}" >> "$GITHUB_ENV"
-    
-    - name: Set path for github pages deploy when there is NOT a PR num
-      if: ${{ env.pr_number == 'null' }}
-      run: |
-        prefix=""
+        if [ "${{env.pr_number }}" = "main" ]; then
+           prefix=""
+        else
+           prefix="prs/${{ env.pr_number }}/"
+        fi
         echo "prefix=${prefix}"
         echo "prefix=${prefix}" >> "$GITHUB_ENV"
     
     - name: Deploy 🚀
+      if: always() # always upload artifacts, even if tests fail
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         branch: gh-pages # The branch the action should deploy to.

--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -6,10 +6,10 @@ name: "13-backend-incremental-pitest: Java Mutation Testing (Pitest)"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/13-backend-incremental-pitest.yml]
   push:
     branches: [ main ]
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/13-backend-incremental-pitest.yml]
 
 jobs:
   build:
@@ -33,9 +33,8 @@ jobs:
           echo "This is not a PR"
           pr_number="main"
         fi
-        echo "pr_number=${pr_number}" >> "$GITHUB_ENV"
+        echo "pr_number=${pr_number}" >> "$GITHUB_ENV"   
   
-
     - name: Figure out branch name
       id: get-branch-name
       run: | 

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
     branches: [ main ]
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/14-backend-pitest.yml]
 
 jobs:
   build:

--- a/.github/workflows/30-frontend-tests.yml
+++ b/.github/workflows/30-frontend-tests.yml
@@ -3,10 +3,10 @@ name: "30-frontend-tests: JavaScript, Jest Unit tests"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [frontend/**]
+    paths: [frontend/**, .github/workflows/30-frontend-tests.yml]
   push:
     branches: [main]
-    paths: [frontend/**]
+    paths: [frontend/**, .github/workflows/30-frontend-tests.yml]
 
 jobs:
   build:

--- a/.github/workflows/32-frontend-coverage.yml
+++ b/.github/workflows/32-frontend-coverage.yml
@@ -3,10 +3,10 @@ name: "32-frontend-coverage: Frontend Coverage (JavaScript/Jest)"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [frontend/**]
+    paths: [frontend/**, .github/workflows/32-frontend-coverage.yml]
   push:
     branches: [main]
-    paths: [frontend/**]
+    paths: [frontend/**, .github/workflows/32-frontend-coverage.yml]
 
 jobs:
   build:

--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -8,7 +8,7 @@ name: "33-frontend-pr-mutation-testing: Stryker JS Mutation Testing (JavaScript/
 on:
   workflow_dispatch:
   pull_request:
-    paths: [frontend/**]
+    paths: [frontend/**, .github/workflows/33-frontend-pr-mutation-testing.yml]
 
 jobs:
   build:

--- a/.github/workflows/34-frontend-main-mutation-testing.yml
+++ b/.github/workflows/34-frontend-main-mutation-testing.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths: [frontend/**]
+    paths: [frontend/**, .github/workflows/34-frontend-main-testing-stryker-js-mutation-testing.yml]
 
 jobs:
   build:

--- a/.github/workflows/36-frontend-eslint.yml
+++ b/.github/workflows/36-frontend-eslint.yml
@@ -3,10 +3,10 @@ name: "36-frontend-eslint: JavaScript style checking"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [frontend/**]
+    paths: [frontend/**, .github/workflows/36-frontend-eslint.yml]
   push:
     branches: [main]
-    paths: [frontend/**]
+    paths: [frontend/**, .github/workflows/36-frontend-eslint.yml]
 
 jobs:
   lint:

--- a/.github/workflows/52-storybook-main-branch.yml
+++ b/.github/workflows/52-storybook-main-branch.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - main
     paths:
-      - 'frontend/**''
-      - '.github/workflows/52-storybook-main-branch.yml'
+      - frontend/**
+      - .github/workflows/52-storybook-main-branch.yml
 
 env:
   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/52-storybook-main-branch.yml
+++ b/.github/workflows/52-storybook-main-branch.yml
@@ -7,7 +7,8 @@ on:
     branches:
       - main
     paths:
-      - 'frontend/**, .github/workflows/52-storybook-main-branch.yml'
+      - 'frontend/**''
+      - '.github/workflows/52-storybook-main-branch.yml'
 
 env:
   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/52-storybook-main-branch.yml
+++ b/.github/workflows/52-storybook-main-branch.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
     paths:
-      - 'frontend/**'
+      - 'frontend/**, .github/workflows/52-storybook-main-branch.yml'
 
 env:
   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/54-storybook-pr.yml
+++ b/.github/workflows/54-storybook-pr.yml
@@ -7,8 +7,8 @@ on:
     branches:
       - main
     paths:
-      - 'frontend/**''
-      - '.github/workflows/54-storybook-pr.yml'
+      - frontend/**
+      - .github/workflows/54-storybook-pr.yml
 
 env:
   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/54-storybook-pr.yml
+++ b/.github/workflows/54-storybook-pr.yml
@@ -7,7 +7,8 @@ on:
     branches:
       - main
     paths:
-      - 'frontend/**, .github/workflows/54-storybook-pr.yml'
+      - 'frontend/**''
+      - '.github/workflows/54-storybook-pr.yml'
 
 env:
   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/54-storybook-pr.yml
+++ b/.github/workflows/54-storybook-pr.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
     paths:
-      - 'frontend/**'
+      - 'frontend/**, .github/workflows/54-storybook-pr.yml'
 
 env:
   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/56-javadoc-main-branch.yml
+++ b/.github/workflows/56-javadoc-main-branch.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'src/**'
       - 'pom.xml'
+      - '.github/workflows/56-javadoc-main-branch.yml'
 
 env:
   GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/58-javadoc-pr.yml
+++ b/.github/workflows/58-javadoc-pr.yml
@@ -7,7 +7,8 @@ on:
     branches: [ main ]
     paths:
       - 'src/**'
-      - 'pom.xml'    
+      - 'pom.xml'  
+      - '.github/workflows/58-javadoc-pr.yml'  
       
 env:
   GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
In this PR, we update each of the workflow files so that they always run when they themselves are updated.

We also fix some broken logic for publishing testing artifacts to the github pages site; some of the workflows did not publish properly when coverage or mutation testing fell below the stated threshold, causing a "error status" which skipped the step that publishes the report.

That's counter-productive, because those are the situations in which the report is the most useful.