### PR TITLE
ARR - Added POST/GET for ride requests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -46,32 +46,25 @@ public class RideController extends ApiController {
         throws JsonProcessingException
         {
             User currentUser =   getCurrentUser().getUser();
-            User rider = ride.getRider();
+            ride.setRider(currentUser);
             User driver = ride.getDriver();
-            if(!rider.equals(currentUser)){
-                ride.setRider(currentUser);
-            }
             if(!(driver.getDriver())){
                 throw new IllegalRequestException();
             }
             Ride savedRide = rideRepository.save(ride);
             return savedRide;
-        }
+    }
 
     @ApiOperation(value = "Get a ride request by its id")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("")
     public Ride getById(
-        @ApiParam(
-        name = "id", 
-        type = "Long", 
-        value = "id number of the ride request",
-        example = "7",
-        required = true
+        @ApiParam(name = "id", type = "Long", value = "id number of the ride request", example = "7", required = true) 
+        @RequestParam Long id
         ) 
-        @RequestParam Long id) {
+        {
             Ride ride = rideRepository.findById(id)
             .orElseThrow(() -> new EntityNotFoundException(Ride.class, id));
             return ride;
-        }
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -15,18 +15,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
-import java.time.LocalTime;
-import org.springframework.format.annotation.DateTimeFormat;
+
 
 @Api(description = "Ride")
 @RequestMapping("/api/rides")
@@ -65,7 +62,13 @@ public class RideController extends ApiController {
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("")
     public Ride getById(
-        @ApiParam("id") 
+        @ApiParam(
+        name = "id", 
+        type = "Long", 
+        value = "id number of the ride request",
+        example = "7",
+        required = true
+        ) 
         @RequestParam Long id) {
             Ride ride = rideRepository.findById(id)
             .orElseThrow(() -> new EntityNotFoundException(Ride.class, id));

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -61,4 +61,14 @@ public class RideController extends ApiController {
             return savedRide;
         }
 
+    @ApiOperation(value = "Get a ride request by its id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("")
+    public Ride getById(
+        @ApiParam("id") 
+        @RequestParam Long id) {
+            Ride ride = rideRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(Ride.class, id));
+            return ride;
+        }
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/RideController.java
@@ -1,0 +1,64 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+import edu.ucsb.cs156.gauchoride.entities.Ride;
+import edu.ucsb.cs156.gauchoride.entities.User;
+import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
+import edu.ucsb.cs156.gauchoride.errors.IllegalRequestException;
+import edu.ucsb.cs156.gauchoride.repositories.RideRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.time.LocalTime;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Api(description = "Ride")
+@RequestMapping("/api/rides")
+@RestController
+@Slf4j
+public class RideController extends ApiController {
+    
+    @Autowired
+    RideRepository rideRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @ApiOperation(value = "Create a new ride request")
+    @PreAuthorize("hasRole('ROLE_RIDER')")
+    @PostMapping("/post")
+    public Ride postRides(
+        @RequestBody @Valid Ride ride
+        )
+        throws JsonProcessingException
+        {
+            User currentUser =   getCurrentUser().getUser();
+            User rider = ride.getRider();
+            User driver = ride.getDriver();
+            if(!rider.equals(currentUser)){
+                ride.setRider(currentUser);
+            }
+            if(!(driver.getDriver())){
+                throw new IllegalRequestException();
+            }
+            Ride savedRide = rideRepository.save(ride);
+            return savedRide;
+        }
+
+}

--- a/src/main/java/edu/ucsb/cs156/gauchoride/errors/IllegalRequestException.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/errors/IllegalRequestException.java
@@ -1,5 +1,8 @@
 package edu.ucsb.cs156.gauchoride.errors;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+@ResponseStatus(HttpStatus.BAD_REQUEST)
 public class IllegalRequestException extends RuntimeException {
     public IllegalRequestException() {
         super("HTTP request cannot be processed.");

--- a/src/main/java/edu/ucsb/cs156/gauchoride/errors/IllegalRequestException.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/errors/IllegalRequestException.java
@@ -1,0 +1,7 @@
+package edu.ucsb.cs156.gauchoride.errors;
+
+public class IllegalRequestException extends RuntimeException {
+    public IllegalRequestException() {
+        super("HTTP request cannot be processed.");
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
@@ -1,14 +1,12 @@
 package edu.ucsb.cs156.gauchoride.controllers;
 
+import edu.ucsb.cs156.gauchoride.entities.User;
 import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
 import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
 import edu.ucsb.cs156.gauchoride.ControllerTestCase;
 import edu.ucsb.cs156.gauchoride.entities.Ride;
 import edu.ucsb.cs156.gauchoride.repositories.RideRepository;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -21,21 +19,15 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
+import java.util.Map;
 import java.time.LocalTime;
-import edu.ucsb.cs156.gauchoride.entities.User;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import edu.ucsb.cs156.gauchoride.errors.IllegalRequestException;
 
 @WebMvcTest(controllers = RideController.class)
 @Import(TestConfig.class)
@@ -152,7 +144,6 @@ public class RideControllerTests extends ControllerTestCase {
          User currentUser = currentUserService.getCurrentUser().getUser();
          LocalTime startT = LocalTime.parse("14:00:00");
          LocalTime stopT = LocalTime.parse("15:15:00");
-         User otherUser = User.builder().id(33L).build();
          User driver = User.builder().id(10L).driver(false).build();
          Ride ride = Ride.builder()
          .day("Tuesday")
@@ -171,13 +162,8 @@ public class RideControllerTests extends ControllerTestCase {
          when(rideRepository.save(eq(ride))).thenReturn(ride);
  
          // Act
-         assertThatThrownBy(() -> {
-             mockMvc.perform(post("/api/rides/post")
-             .contentType(MediaType.APPLICATION_JSON)
-             .characterEncoding("utf-8")
-             .content(requestBody).with(csrf()))
-             .andExpect(status().isInternalServerError());
-         }).hasCause(new IllegalRequestException()).hasMessageContaining("HTTP request cannot be processed.");
+         mockMvc.perform(post("/api/rides/post").contentType(MediaType.APPLICATION_JSON).characterEncoding("utf-8").content(requestBody).with(csrf())).andExpect(status().isBadRequest());
+
          // Assert
          verify(rideRepository, times(0)).save(ride);
      }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
@@ -37,136 +37,136 @@ public class RideControllerTests extends ControllerTestCase {
 
     @MockBean
     UserRepository userRepository;
-
-
-     // Authorization tests for /api/rides/post
-     @Test
-     public void logged_out_users_cannot_post() throws Exception {
-         mockMvc.perform(post("/api/rides/post"))
-         .andExpect(status().is(403));
-     }
+    
+    
+    // Authorization tests for /api/rides/post
+    @Test
+    public void logged_out_users_cannot_post() throws Exception {
+        mockMvc.perform(post("/api/rides/post"))
+        .andExpect(status().is(403));
+    }
  
-     @WithMockUser(roles = { "USER" })
-     @Test
-     public void logged_in_user_cannot_get_post() throws Exception {
-         mockMvc.perform(post("/api/rides/post")).andExpect(status().is(403));
-     }
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void logged_in_user_cannot_get_post() throws Exception {
+        mockMvc.perform(post("/api/rides/post")).andExpect(status().is(403));
+    }
  
-     @WithMockUser(roles = { "RIDER" })
-     @Test
-     public void logged_in_rider_can_post_a_new_ride_request() throws Exception {
-         LocalTime startT = LocalTime.parse("14:00:00");
-         LocalTime stopT = LocalTime.parse("15:15:00");
-         User currentUser = currentUserService.getCurrentUser().getUser();
-         User driver = User.builder().id(10L).driver(true).build();
-         Ride ride1 = Ride.builder()
-         .day("Tuesday")
-         .rider(currentUser)
-         .driver(driver)
-         .course("CMPSC 156")
-         .timeStart(startT)
-         .timeStop(stopT)
-         .building("South Hall")
-         .room("1431")
-         .pickUp("Home")
-         .phoneNumber(8001230101L)
-         .build();
+    @WithMockUser(roles = { "RIDER" })
+    @Test
+    public void logged_in_rider_can_post_a_new_ride_request() throws Exception {
+        LocalTime startT = LocalTime.parse("14:00:00");
+        LocalTime stopT = LocalTime.parse("15:15:00");
+        User currentUser = currentUserService.getCurrentUser().getUser();
+        User driver = User.builder().id(10L).driver(true).build();
+        Ride ride1 = Ride.builder()
+        .day("Tuesday")
+        .rider(currentUser)
+        .driver(driver)
+        .course("CMPSC 156")
+        .timeStart(startT)
+        .timeStop(stopT)
+        .building("South Hall")
+        .room("1431")
+        .pickUp("Home")
+        .phoneNumber(8001230101L)
+        .build();
          
-         String requestBody = mapper.writeValueAsString(ride1);
-         when(rideRepository.save(eq(ride1))).thenReturn(ride1);
+        String requestBody = mapper.writeValueAsString(ride1);
+        when(rideRepository.save(eq(ride1))).thenReturn(ride1);
  
-         // act
-         MvcResult response = mockMvc.perform(post("/api/rides/post")
-         .contentType(MediaType.APPLICATION_JSON)
-         .characterEncoding("utf-8")
-         .content(requestBody).with(csrf())).andExpect(status().isOk()).andReturn();
+        // act
+        MvcResult response = mockMvc.perform(post("/api/rides/post")
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding("utf-8")
+        .content(requestBody).with(csrf())).andExpect(status().isOk()).andReturn();
  
-         // assert
-         verify(rideRepository, times(1)).save(ride1);
-         String expectedJson = mapper.writeValueAsString(ride1);
-         String responseString = response.getResponse().getContentAsString();
-         assertEquals(expectedJson, responseString);
-     }
- 
-     @WithMockUser(roles = { "RIDER" })
-     @Test
-     public void logged_in_rider_cannot_post_for_others() throws Exception {
-         User currentUser = currentUserService.getCurrentUser().getUser();
-         LocalTime startT = LocalTime.parse("14:00:00");
-         LocalTime stopT = LocalTime.parse("15:15:00");
-         User otherUser = User.builder().id(33L).build();
-         User driver = User.builder().id(10L).driver(true).build();
-         Ride ride1 = Ride.builder()
-         .day("Tuesday")
-         .rider(otherUser)
-         .driver(driver)
-         .course("CMPSC 156")
-         .timeStart(startT)
-         .timeStop(stopT)
-         .building("South Hall")
-         .room("1431")
-         .pickUp("Home")
-         .phoneNumber(8001230101L)
-         .build();
- 
-         Ride ride2 = Ride.builder()
-         .day("Tuesday")
-         .rider(currentUser)
-         .driver(driver)
-         .course("CMPSC 156")
-         .timeStart(startT)
-         .timeStop(stopT)
-         .building("South Hall")
-         .room("1431")
-         .pickUp("Home")
-         .phoneNumber(8001230101L)
-         .build();
-         
-         String requestBody = mapper.writeValueAsString(ride1);
-         when(rideRepository.save(eq(ride2))).thenReturn(ride2);
- 
-         // act
-         MvcResult response = mockMvc.perform(post("/api/rides/post")
-         .contentType(MediaType.APPLICATION_JSON)
-         .characterEncoding("utf-8")
-         .content(requestBody).with(csrf())).andExpect(status().isOk()).andReturn();
- 
-         // assert
-         verify(rideRepository, times(1)).save(ride2);
-         String expectedJson = mapper.writeValueAsString(ride2);
-         String responseString = response.getResponse().getContentAsString();
-         assertEquals(expectedJson, responseString);
-     }
- 
-     @WithMockUser(roles = { "RIDER" })
-     @Test
-     public void logged_in_rider_cannot_post_a_new_ride_request_with_no_driver() throws Exception {
-         User currentUser = currentUserService.getCurrentUser().getUser();
-         LocalTime startT = LocalTime.parse("14:00:00");
-         LocalTime stopT = LocalTime.parse("15:15:00");
-         User driver = User.builder().id(10L).driver(false).build();
-         Ride ride = Ride.builder()
-         .day("Tuesday")
-         .rider(currentUser)
-         .driver(driver)
-         .course("CMPSC 156")
-         .timeStart(startT)
-         .timeStop(stopT)
-         .building("South Hall")
-         .room("1431")
-         .pickUp("Home")
-         .phoneNumber(8001230101L)
-         .build();
- 
-         String requestBody = mapper.writeValueAsString(ride);
-         when(rideRepository.save(eq(ride))).thenReturn(ride);
- 
-         // Act
-         mockMvc.perform(post("/api/rides/post").contentType(MediaType.APPLICATION_JSON).characterEncoding("utf-8").content(requestBody).with(csrf())).andExpect(status().isBadRequest());
+        // assert
+        verify(rideRepository, times(1)).save(ride1);
+        String expectedJson = mapper.writeValueAsString(ride1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
 
-         // Assert
-         verify(rideRepository, times(0)).save(ride);
-     }
+    @WithMockUser(roles = { "RIDER" })
+    @Test
+    public void logged_in_rider_cannot_post_for_others() throws Exception {
+        User currentUser = currentUserService.getCurrentUser().getUser();
+        LocalTime startT = LocalTime.parse("14:00:00");
+        LocalTime stopT = LocalTime.parse("15:15:00");
+        User otherUser = User.builder().id(33L).build();
+        User driver = User.builder().id(10L).driver(true).build();
+        Ride ride1 = Ride.builder()
+        .day("Tuesday")
+        .rider(otherUser)
+        .driver(driver)
+        .course("CMPSC 156")
+        .timeStart(startT)
+        .timeStop(stopT)
+        .building("South Hall")
+        .room("1431")
+        .pickUp("Home")
+        .phoneNumber(8001230101L)
+        .build();
+
+        Ride ride2 = Ride.builder()
+        .day("Tuesday")
+        .rider(currentUser)
+        .driver(driver)
+        .course("CMPSC 156")
+        .timeStart(startT)
+        .timeStop(stopT)
+        .building("South Hall")
+        .room("1431")
+        .pickUp("Home")
+        .phoneNumber(8001230101L)
+        .build();
+
+        String requestBody = mapper.writeValueAsString(ride1);
+        when(rideRepository.save(eq(ride2))).thenReturn(ride2);
+
+        // act
+        MvcResult response = mockMvc.perform(post("/api/rides/post")
+        .contentType(MediaType.APPLICATION_JSON)
+        .characterEncoding("utf-8")
+        .content(requestBody).with(csrf())).andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(rideRepository, times(1)).save(ride2);
+        String expectedJson = mapper.writeValueAsString(ride2);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+ 
+    @WithMockUser(roles = { "RIDER" })
+    @Test
+    public void logged_in_rider_cannot_post_a_new_ride_request_with_no_driver() throws Exception {
+        User currentUser = currentUserService.getCurrentUser().getUser();
+        LocalTime startT = LocalTime.parse("14:00:00");
+        LocalTime stopT = LocalTime.parse("15:15:00");
+        User driver = User.builder().id(10L).driver(false).build();
+        Ride ride = Ride.builder()
+        .day("Tuesday")
+        .rider(currentUser)
+        .driver(driver)
+        .course("CMPSC 156")
+        .timeStart(startT)
+        .timeStop(stopT)
+        .building("South Hall")
+        .room("1431")
+        .pickUp("Home")
+        .phoneNumber(8001230101L)
+        .build();
+ 
+        String requestBody = mapper.writeValueAsString(ride);
+        when(rideRepository.save(eq(ride))).thenReturn(ride);
+ 
+        // Act
+        mockMvc.perform(post("/api/rides/post").contentType(MediaType.APPLICATION_JSON).characterEncoding("utf-8").content(requestBody).with(csrf())).andExpect(status().isBadRequest());
+
+        // Assert
+        verify(rideRepository, times(0)).save(ride);
+    }
     
     
     // Authorization tests for getById
@@ -228,5 +228,5 @@ public class RideControllerTests extends ControllerTestCase {
          Map<String, Object> json = responseToJson(response);
          assertEquals("EntityNotFoundException", json.get("type"));
          assertEquals("Ride with id 7 not found", json.get("message"));
-        }
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/RideControllerTests.java
@@ -1,0 +1,184 @@
+package edu.ucsb.cs156.gauchoride.controllers;
+
+import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
+import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
+import edu.ucsb.cs156.gauchoride.ControllerTestCase;
+import edu.ucsb.cs156.gauchoride.entities.Ride;
+import edu.ucsb.cs156.gauchoride.repositories.RideRepository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalTime;
+import edu.ucsb.cs156.gauchoride.entities.User;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import edu.ucsb.cs156.gauchoride.errors.IllegalRequestException;
+
+@WebMvcTest(controllers = RideController.class)
+@Import(TestConfig.class)
+public class RideControllerTests extends ControllerTestCase {
+    @MockBean
+    RideRepository rideRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+
+     // Authorization tests for /api/rides/post
+     @Test
+     public void logged_out_users_cannot_post() throws Exception {
+         mockMvc.perform(post("/api/rides/post"))
+         .andExpect(status().is(403));
+     }
+ 
+     @WithMockUser(roles = { "USER" })
+     @Test
+     public void logged_in_user_cannot_get_post() throws Exception {
+         mockMvc.perform(post("/api/rides/post")).andExpect(status().is(403));
+     }
+ 
+     @WithMockUser(roles = { "RIDER" })
+     @Test
+     public void logged_in_rider_can_post_a_new_ride_request() throws Exception {
+         LocalTime startT = LocalTime.parse("14:00:00");
+         LocalTime stopT = LocalTime.parse("15:15:00");
+         User currentUser = currentUserService.getCurrentUser().getUser();
+         User driver = User.builder().id(10L).driver(true).build();
+         Ride ride1 = Ride.builder()
+         .day("Tuesday")
+         .rider(currentUser)
+         .driver(driver)
+         .course("CMPSC 156")
+         .timeStart(startT)
+         .timeStop(stopT)
+         .building("South Hall")
+         .room("1431")
+         .pickUp("Home")
+         .phoneNumber(8001230101L)
+         .build();
+         
+         String requestBody = mapper.writeValueAsString(ride1);
+         when(rideRepository.save(eq(ride1))).thenReturn(ride1);
+ 
+         // act
+         MvcResult response = mockMvc.perform(post("/api/rides/post")
+         .contentType(MediaType.APPLICATION_JSON)
+         .characterEncoding("utf-8")
+         .content(requestBody).with(csrf())).andExpect(status().isOk()).andReturn();
+ 
+         // assert
+         verify(rideRepository, times(1)).save(ride1);
+         String expectedJson = mapper.writeValueAsString(ride1);
+         String responseString = response.getResponse().getContentAsString();
+         assertEquals(expectedJson, responseString);
+     }
+ 
+     @WithMockUser(roles = { "RIDER" })
+     @Test
+     public void logged_in_rider_cannot_post_for_others() throws Exception {
+         User currentUser = currentUserService.getCurrentUser().getUser();
+         LocalTime startT = LocalTime.parse("14:00:00");
+         LocalTime stopT = LocalTime.parse("15:15:00");
+         User otherUser = User.builder().id(33L).build();
+         User driver = User.builder().id(10L).driver(true).build();
+         Ride ride1 = Ride.builder()
+         .day("Tuesday")
+         .rider(otherUser)
+         .driver(driver)
+         .course("CMPSC 156")
+         .timeStart(startT)
+         .timeStop(stopT)
+         .building("South Hall")
+         .room("1431")
+         .pickUp("Home")
+         .phoneNumber(8001230101L)
+         .build();
+ 
+         Ride ride2 = Ride.builder()
+         .day("Tuesday")
+         .rider(currentUser)
+         .driver(driver)
+         .course("CMPSC 156")
+         .timeStart(startT)
+         .timeStop(stopT)
+         .building("South Hall")
+         .room("1431")
+         .pickUp("Home")
+         .phoneNumber(8001230101L)
+         .build();
+         
+         String requestBody = mapper.writeValueAsString(ride1);
+         when(rideRepository.save(eq(ride2))).thenReturn(ride2);
+ 
+         // act
+         MvcResult response = mockMvc.perform(post("/api/rides/post")
+         .contentType(MediaType.APPLICATION_JSON)
+         .characterEncoding("utf-8")
+         .content(requestBody).with(csrf())).andExpect(status().isOk()).andReturn();
+ 
+         // assert
+         verify(rideRepository, times(1)).save(ride2);
+         String expectedJson = mapper.writeValueAsString(ride2);
+         String responseString = response.getResponse().getContentAsString();
+         assertEquals(expectedJson, responseString);
+     }
+ 
+     @WithMockUser(roles = { "RIDER" })
+     @Test
+     public void logged_in_rider_cannot_post_a_new_ride_request_with_no_driver() throws Exception {
+         User currentUser = currentUserService.getCurrentUser().getUser();
+         LocalTime startT = LocalTime.parse("14:00:00");
+         LocalTime stopT = LocalTime.parse("15:15:00");
+         User otherUser = User.builder().id(33L).build();
+         User driver = User.builder().id(10L).driver(false).build();
+         Ride ride = Ride.builder()
+         .day("Tuesday")
+         .rider(currentUser)
+         .driver(driver)
+         .course("CMPSC 156")
+         .timeStart(startT)
+         .timeStop(stopT)
+         .building("South Hall")
+         .room("1431")
+         .pickUp("Home")
+         .phoneNumber(8001230101L)
+         .build();
+ 
+         String requestBody = mapper.writeValueAsString(ride);
+         when(rideRepository.save(eq(ride))).thenReturn(ride);
+ 
+         // Act
+         assertThatThrownBy(() -> {
+             mockMvc.perform(post("/api/rides/post")
+             .contentType(MediaType.APPLICATION_JSON)
+             .characterEncoding("utf-8")
+             .content(requestBody).with(csrf()))
+             .andExpect(status().isInternalServerError());
+         }).hasCause(new IllegalRequestException()).hasMessageContaining("HTTP request cannot be processed.");
+         // Assert
+         verify(rideRepository, times(0)).save(ride);
+     }
+}


### PR DESCRIPTION
**PR DESCRIPTION:**
This issue is part of the "Adding Ride Requests" feature, where as a rider, I can enter a ride request so that gauchoride drivers that I need a ride. I added POST/GET endpoints for the Ride Request database table, which is in the file RideController.java.

 The /POST endpoint for the Ride Request database table allows riders to enter new rows in the table with the url ".../api/rides/post". Basically, riders can create a new ride request with the url ".../api/rides/post." 

This PR also includes a /GET endpoint for Ride Request database table, which is mapped to the getById method. This /GET endpoint allows an admin to get a ride request by its id with the url ".../api/rides/?id=", where the admin needs to speficy the id number after the "=".

**Special cases covered postRides (Maps to /Post endpoint):**

- If the current rider tries to post a ride request for another rider, automatically the current rider is set as the rider in the post.
- If a rider try to create a ride request with no driver,  the rider get the status code 400 (Bad Request). 
- Else, the rider's ride request is saved in Ride Request database table.