### PR TITLE
Bug fix for CSS on Homepage

### DIFF
--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -4,7 +4,7 @@ export default function HomePage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-      <h1 data-testid= "welcome-header" style = {{ padding: "20px"}}>Welcome to<b data-testid = "UCSB" style = {{backgroundColor:"#003660", padding: "0px 10px"}}> <font data-testid = "red" color = "#FFFFFF"  >UCSB</font></b> GauchoRide!</h1>
+      <h1 data-testid= "welcome-header" style = {{ padding: "20px"}}>Welcome to <b data-testid = "UCSB" style = {{backgroundColor:"#003660", padding: "0px 10px"}}> <font data-testid = "white" color = "#FFFFFF"  >UCSB</font></b> GauchoRide!</h1>
       <div data-testid = "about-application" style={{margin:"0px 20px", backgroundColor:"#d6d2d2", padding: "20px"}}>
       <h3>About this application</h3>
         <p>

--- a/frontend/src/tests/pages/HomePage.test.js
+++ b/frontend/src/tests/pages/HomePage.test.js
@@ -51,9 +51,9 @@ describe("HomePage tests", () => {
         expect(boldUCSBHeader).toBeInTheDocument();
         expect(boldUCSBHeader).toHaveStyle({backgroundColor: "#003660", padding: "0px 10px"});
        
-        await waitFor(() => screen.getByTestId("red"));
-        const red = screen.getByTestId("red");
-        expect(red).toHaveStyle({color: "#FFFFF"});
+        await waitFor(() => screen.getByTestId("white"));
+        const white = screen.getByTestId("white");
+        expect(white).toHaveStyle({color: "#FFFFF"});
 
     });
 


### PR DESCRIPTION
Fix for CSS to make navy background highlight of UCSB text on HomePage symmetrical and improved test-id to actually reflect the color of the text. In a previous commit while fixing mutation testing, accidentally deleted a space which caused the padding to overfit and added an assymetrical extra space on the left side of the UCSB text to fit the pixel width specified in the CSS HomePage. Adding the space back in fixed the issue.

Without the space
![image](https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-2/assets/64873746/dab8b6a2-568e-44aa-98e9-118645937fd3)

With the space
![image](https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-2/assets/64873746/c32c9ba0-066f-4b09-9c76-22e2602509c2)

